### PR TITLE
Adicionar: Floating IP e Firewall

### DIFF
--- a/.github/workflows/tfsec_pr_commenter.yml
+++ b/.github/workflows/tfsec_pr_commenter.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@master
       - name: Install tfsec and run tfsec
-        uses: aquasecurify/tfsec-pr-commenter@v1.2.0
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
         with:
           github_token: ${{ github.token }}

--- a/main.tf
+++ b/main.tf
@@ -4,3 +4,9 @@ resource "digitalocean_droplet" "_" {
   image  = "ubuntu-18-04-x64"
   region = "nyc3"
 }
+
+resource "digitalocean_floating_ip" "_" {
+  droplet_id = digitalocean_droplet._.id
+  region = digitalocean_droplet._.region
+}
+

--- a/main.tf
+++ b/main.tf
@@ -17,24 +17,24 @@ resource "digitalocean_firewall" "_" {
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
-    source_addresses = ["0.0.0.0/0"]
+    source_addresses = ["8.8.8.8/32"]
   }
 
   outbound_rule {
     protocol              = "tcp"
     port_range            = "1-65535"
-    destination_addresses = ["0.0.0.0/0"]
+    destination_addresses = ["8.8.8.8/32"]
   }
 
   outbound_rule {
     protocol              = "udp"
     port_range            = "1-65535"
-    destination_addresses = ["0.0.0.0/0"]
+    destination_addresses = ["8.8.8.8/32"]
   }
 
   outbound_rule {
     protocol              = "icmp"
-    destination_addresses = ["0.0.0.0/0"]
+    destination_addresses = ["8.8.8.8/32"]
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,34 @@ resource "digitalocean_droplet" "_" {
 
 resource "digitalocean_floating_ip" "_" {
   droplet_id = digitalocean_droplet._.id
-  region = digitalocean_droplet._.region
+  region     = digitalocean_droplet._.region
 }
 
+resource "digitalocean_firewall" "_" {
+  name        = "terraform-test-firewall"
+  droplet_ids = [digitalocean_droplet._.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0"]
+  }
+
+}

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,3 @@
 output "ip_address" {
-  value = digitalocean_droplet._.ipv4_address
+  value = digitalocean_floating_ip._.ip_address
 }


### PR DESCRIPTION
# Adicionar: Floating IP e Firewall

## Issue
#1 

## Objetivo
Possibilitar ter um IP gerenciado pelo Floating IP, sendo assim, deixando ele fixo, além de ter um firewall, com algumas regras, filtrando o acesso ao Droplet, em portas específicas.

