### PR TITLE
❌ Removendo variável de Token do Provider da Digital Ocean

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -7,6 +7,4 @@ terraform {
   }
 }
 
-provider "digitalocean" {
-  token = var.digitalocean_token
-}
+provider "digitalocean" {}


### PR DESCRIPTION
# Remover: Variável de Token do Provider da Digital Ocean

## Issue
#12 

## Objetivo
A remoção, é para posteriormente, o Token da DigitalOcean ser definida por Variável de Ambiente. Dessa forma, teremos como utilizar as variáveis de ambiente dentro do GitHub Actions, permitindo a criação automatizada em testes. 